### PR TITLE
Feature direct connection

### DIFF
--- a/src/main/java/jenkins/plugins/testdroid/DeviceSessionWrapper.java
+++ b/src/main/java/jenkins/plugins/testdroid/DeviceSessionWrapper.java
@@ -239,6 +239,7 @@ public class DeviceSessionWrapper extends BuildWrapper {
                 //1) request device session
                 try {
                     session = client.post("/me/device-sessions", deviceSessionsParams, APIDeviceSession.class);
+                    sessionId = session.getId();
                 } catch (APIException e) {
                     //allow to continue if device lock can't be created otherwise throw IOException
                     if (e.getStatus() != 400) {
@@ -251,6 +252,7 @@ public class DeviceSessionWrapper extends BuildWrapper {
                     logger.info("Timeout when waiting for device session " + session.getId());
                     releaseDeviceSession(logger, client, session.getId(), null);
                     session = null;
+                    sessionId = null;
 
                 }
 

--- a/src/main/resources/jenkins/plugins/testdroid/DeviceSessionWrapper/config.jelly
+++ b/src/main/resources/jenkins/plugins/testdroid/DeviceSessionWrapper/config.jelly
@@ -38,6 +38,9 @@
                 <f:textbox name="flashProjectName"
                            value="${instance.flashProjectName}" />
             </f:entry>
+            <f:entry field="opensConnections">
+                <f:checkbox name="opensConnections" title="After flashing make the device available for adb and marionette connections"/>
+            </f:entry>
         </f:advanced>
     </f:entry>
 


### PR DESCRIPTION
This feature adds checkbox under advanced settings where project name is specified. If checkbox is checked plugin opens queries adb/marionette port status after the flashing is completed without opening a new session. Note. The project needs to be configured to use this feature also in cloud, currently "flash-fxos-task-cluster" project is the one which support this. 